### PR TITLE
Fix a few issues with the forbidden syscalls test

### DIFF
--- a/tests/forbidden-syscalls.rs
+++ b/tests/forbidden-syscalls.rs
@@ -22,7 +22,7 @@ fn profile() -> Profile {
 fn test_syscall(number: c_int) {
     ChildSandbox::new(profile()).activate().unwrap();
     unsafe {
-        syscall(number);
+        syscall(number, -1, -1, -1, -1, -1, -1);
     }
 }
 

--- a/tests/forbidden-syscalls.rs
+++ b/tests/forbidden-syscalls.rs
@@ -12,7 +12,7 @@ use std::env;
 #[cfg(target_os="linux")]
 use gaol::platform::linux::seccomp::ALLOWED_SYSCALLS;
 
-const MAX_SYSCALL: u32 = 320;
+const MAX_SYSCALL: u32 = 400;
 
 fn profile() -> Profile {
     Profile::new(Vec::new()).unwrap()


### PR DESCRIPTION
Here are a couple of fixes for issues found when porting gaol to ppc64le.