### PR TITLE
Fix missing syscalls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,5 @@ name = "system-info-read"
 path = "tests/system-info-read.rs"
 harness = false
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dump_bpf_sockets)'] }

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -90,9 +90,11 @@ impl ChildSandboxMethods for ChildSandbox {
         if namespace::activate(&self.profile).is_err() {
             return Err(())
         }
-        if misc::activate().is_err() {
-            return Err(())
-        }
+        // This is incompatible with many syscalls, but the idea itself is not bad.
+        // After a refactor it may be useful again
+        // if misc::activate().is_err() {
+        //     return Err(())
+        // }
         match Filter::new(&self.profile).activate() {
             Ok(_) => Ok(()),
             Err(_) => Err(()),

--- a/platform/linux/mod.rs
+++ b/platform/linux/mod.rs
@@ -57,9 +57,6 @@ impl Sandbox {
         let filter = Filter::new(&self.profile);
         filter.dump();
     }
-
-    #[cfg(not(dump_bpf_sockets))]
-    fn dump_filter(&self) {}
 }
 
 impl SandboxMethods for Sandbox {
@@ -68,6 +65,7 @@ impl SandboxMethods for Sandbox {
     }
 
     fn start(&self, command: &mut Command) -> io::Result<Process> {
+        #[cfg(dump_bpf_sockets)]
         self.dump_filter();
         namespace::start(&self.profile, command)
     }

--- a/platform/linux/seccomp.rs
+++ b/platform/linux/seccomp.rs
@@ -335,9 +335,6 @@ impl Filter {
         }
     }
 
-    #[cfg(not(dump_bpf_sockets))]
-    pub fn dump(&self) {}
-
     /// Activates this filter, applying all of its restrictions forevermore. This can only be done
     /// once.
     pub fn activate(&self) -> Result<(),c_int> {

--- a/tests/file-read-all.rs
+++ b/tests/file-read-all.rs
@@ -8,9 +8,8 @@ extern crate rand;
 use gaol::profile::{Operation, PathPattern, Profile};
 use gaol::sandbox::{ChildSandbox, ChildSandboxMethods, Command, Sandbox, SandboxMethods};
 use libc::c_char;
-use rand::Rng;
-use rand::distributions::Alphanumeric;
-use std::env;
+use rand::distributions::{Alphanumeric, DistString};
+use std::{env, process};
 use std::ffi::{CString, OsStr};
 use std::fs::File;
 use std::io::Write;
@@ -35,13 +34,21 @@ fn prohibition_profile() -> Profile {
 fn allowance_test() {
     let path = PathBuf::from(env::var("GAOL_TEMP_FILE").unwrap());
     ChildSandbox::new(allowance_profile(&path)).activate().unwrap();
-    drop(File::open(&path).unwrap())
+
+    match File::open(&path) {
+        Err(_) => process::exit(31),
+        _ => {},
+    }
 }
 
 fn prohibition_test() {
     let path = PathBuf::from(env::var("GAOL_TEMP_FILE").unwrap());
     ChildSandbox::new(prohibition_profile()).activate().unwrap();
-    drop(File::open(&path).unwrap())
+
+    match File::open(&path) {
+        Err(_) => process::exit(31),
+        _ => {},
+    }
 }
 
 pub fn main() {
@@ -58,15 +65,12 @@ pub fn main() {
         let c_temp_path =
             CString::new(temp_path.as_os_str().to_str().unwrap().as_bytes()).unwrap();
         let mut new_temp_path = [0u8; PATH_MAX];
-        drop(realpath(c_temp_path.as_ptr(), new_temp_path.as_mut_ptr() as *mut c_char));
+        realpath(c_temp_path.as_ptr(), new_temp_path.as_mut_ptr() as *mut c_char);
         let pos = new_temp_path.iter().position(|&x| x == 0).unwrap();
         temp_path = PathBuf::from(OsStr::from_bytes(&new_temp_path[..pos]));
     }
 
-    let mut rng = rand::thread_rng();
-    let suffix: String = std::iter::repeat(())
-        .map(|()| rng.sample(Alphanumeric))
-        .take(6).collect();
+    let suffix = Alphanumeric.sample_string(&mut rand::thread_rng(), 6);
 
     temp_path.push(format!("gaoltest.{}", suffix));
     File::create(&temp_path).unwrap().write_all(b"super secret\n").unwrap();

--- a/tests/network-outbound.rs
+++ b/tests/network-outbound.rs
@@ -5,7 +5,7 @@ extern crate gaol;
 
 use gaol::profile::{AddressPattern, Operation, Profile};
 use gaol::sandbox::{ChildSandbox, ChildSandboxMethods, Command, Sandbox, SandboxMethods};
-use std::env;
+use std::{env, process};
 use std::net::{TcpListener, TcpStream};
 
 static ADDRESS: &'static str = "127.0.0.1:7357";
@@ -20,12 +20,20 @@ fn prohibition_profile() -> Profile {
 
 fn allowance_test() {
     ChildSandbox::new(allowance_profile()).activate().unwrap();
-    drop(TcpStream::connect(ADDRESS).unwrap())
+
+    match TcpStream::connect(ADDRESS) {
+        Err(_) => process::exit(31),
+        _ => {},
+    }
 }
 
 fn prohibition_test() {
     ChildSandbox::new(prohibition_profile()).activate().unwrap();
-    drop(TcpStream::connect(ADDRESS).unwrap())
+
+    match TcpStream::connect(ADDRESS) {
+        Err(_) => process::exit(31),
+        _ => {},
+    }
 }
 
 pub fn main() {

--- a/tests/system-info-read.rs
+++ b/tests/system-info-read.rs
@@ -1,6 +1,8 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
+#![allow(unused_imports, dead_code)]
+
 extern crate gaol;
 extern crate libc;
 


### PR DESCRIPTION
This one is a bit of a workaround.

I may have added a very few unnecessary calls to the list, but in general this is what is missing.
Hard to point out major incompatibilities with servo, but mostly around `ipc-channel`, `script`, `background_hang_monitor`, and of course `shared`.

This was made in tandem with https://github.com/servo/ipc-channel/pull/374

---

Now, I'm not saying this approach is any good... but looking at the time invested compared to what needs to be done... it's not in the same dimension.

I'd say, for now let's just go this way, and later we can make decisions on what we want to achieve, and how.

p.s.: failing tests are also fixed